### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Introduction
 This is a python client implementation of the STOMP protocol.
 
 The client is attempting to be transport layer neutral. This module provides
-functions to create and parse STOMP messages in a programatic fashion. The
+functions to create and parse STOMP messages in a programmatic fashion. The
 messages can be easily generated and parsed, however its up to the user to do
 the sending and receiving. The STOMP protocol specification can be found here:
 
@@ -28,7 +28,7 @@ the sending and receiving. The STOMP protocol specification can be found here:
 
 I've looked at the stomp client by Jason R. Briggs. I've based some of the
 'function to message' generation on how his client does it. The client can
-be found at the follow address however it isn't a dependancy.
+be found at the follow address however it isn't a dependency.
 
 - `stompy <http://www.briggs.net.nz/log/projects/stomppy>`_
 
@@ -83,7 +83,7 @@ Roger Hoover. This removes the extra line ending which can cause problems.
 0.2.4
 ~~~~~
 
-OM: A minor relase fixing the problem whereby uuid would be installed on python2.5+. It
+OM: A minor release fixing the problem whereby uuid would be installed on python2.5+. It
 is not needed after python2.4 as it comes with python. Arfrever Frehtes Taifersar Arahesis
 contributed the fix for this.
 

--- a/lib/stomper.egg-info/PKG-INFO
+++ b/lib/stomper.egg-info/PKG-INFO
@@ -26,7 +26,7 @@ Description: =======
         This is a python client implementation of the STOMP protocol. 
         
         The client is attempting to be transport layer neutral. This module provides 
-        functions to create and parse STOMP messages in a programatic fashion. The 
+        functions to create and parse STOMP messages in a programmatic fashion. The 
         messages can be easily generated and parsed, however its up to the user to do
         the sending and receiving. The STOMP protocol specification can be found here:
         
@@ -82,7 +82,7 @@ Description: =======
         0.2.4
         ~~~~~
         
-        OM: A minor relase fixing the problem whereby uuid would be installed on python2.5+. It 
+        OM: A minor release fixing the problem whereby uuid would be installed on python2.5+. It 
         is not needed after python2.4 as it comes with python. Arfrever Frehtes Taifersar Arahesis 
         contributed the fix for this.
         

--- a/lib/stomper/__init__.py
+++ b/lib/stomper/__init__.py
@@ -2,7 +2,7 @@
 This is a python client implementation of the STOMP protocol.
 
 It aims to be transport layer neutral. This module provides functions to
-create and parse STOMP messages in a programatic fashion.
+create and parse STOMP messages in a programmatic fashion.
 
 The examples package contains two examples using twisted as the transport
 framework. Other frameworks can be used and I may add other examples as
@@ -39,7 +39,7 @@ import doc
 import utils
 import stompbuffer
 
-# This is used as a return from message reponses functions.
+# This is used as a return from message responses functions.
 # It is used more for readability more then anything or reason.
 NO_RESPONSE_NEEDED = ''
 
@@ -79,7 +79,7 @@ class Frame(object):
 
     The method unpack() is used to read a STOMP message into
     a frame instance. It uses the unpack_frame(...) function
-    to do the intial parsing.
+    to do the initial parsing.
 
     The frame has three important member variables:
 
@@ -128,12 +128,12 @@ class Frame(object):
         headers = ''.join(
             ['%s:%s\n' % (f, v) for f, v in self.headers.items()]
         )
-        stomp_mesage = "%s\n%s\n%s%s\n" % (self._cmd, headers, self.body, NULL)
+        stomp_message = "%s\n%s\n%s%s\n" % (self._cmd, headers, self.body, NULL)
 
 #        import pprint
-#        print "stomp_mesage: ", pprint.pprint(stomp_mesage)
+#        print "stomp_message: ", pprint.pprint(stomp_message)
 
-        return stomp_mesage
+        return stomp_message
 
 
     def unpack(self, message):
@@ -287,7 +287,7 @@ def commit(transactionid):
     """STOMP commit command.
 
     Do whatever is required to make the series of actions
-    permenant for this transactionid.
+    permanent for this transactionid.
 
     transactionid:
         This is the id that all actions in this transaction.
@@ -425,9 +425,9 @@ class Engine(object):
 
 
     def connected(self, msg):
-        """No reponse is needed to a connected frame.
+        """No response is needed to a connected frame.
 
-        This method stores the session id as a the
+        This method stores the session id as the
         member sessionId for later use.
 
         returned:
@@ -445,7 +445,7 @@ class Engine(object):
 
         Override this method to handle received messages.
 
-        This function will generate an acknowlege message
+        This function will generate an acknowledge message
         for the given message and transaction (if present).
 
         """

--- a/lib/stomper/doc/stomper.stx
+++ b/lib/stomper/doc/stomper.stx
@@ -20,7 +20,7 @@ Introduction
 This is a python client implementation of the STOMP protocol.
 
 The client is attempting to be transport layer neutral. This module provides
-functions to create and parse STOMP messages in a programatic fashion. The
+functions to create and parse STOMP messages in a programmatic fashion. The
 messages can be easily generated and parsed, however its up to the user to do
 the sending and receiving. The STOMP protocol specification can be found here:
 
@@ -83,7 +83,7 @@ Roger Hoover. This removes the extra line ending which can cause problems.
 0.2.4
 ~~~~~
 
-OM: A minor relase fixing the problem whereby uuid would be installed on python2.5+. It
+OM: A minor release fixing the problem whereby uuid would be installed on python2.5+. It
 is not needed after python2.4 as it comes with python. Arfrever Frehtes Taifersar Arahesis
 contributed the fix for this.
 

--- a/lib/stomper/examples/sender.py
+++ b/lib/stomper/examples/sender.py
@@ -57,7 +57,7 @@ class StompProtocol(Protocol, stomper.Engine):
 
         # ActiveMQ specific headers:
         #
-        # prevent the messages we send comming back to us.
+        # prevent the messages we send coming back to us.
         f.headers['activemq.noLocal'] = 'true'
         
         return f.pack()

--- a/lib/stomper/examples/stompbuffer-tx.py
+++ b/lib/stomper/examples/stompbuffer-tx.py
@@ -36,7 +36,7 @@ class StompProtocol(Protocol, stomper.Engine):
         """
         stomper.Engine.connected(self, msg)
 
-        self.log.info("Connected: session %s. Begining say hello." % msg['headers']['session'])
+        self.log.info("Connected: session %s. Beginning say hello." % msg['headers']['session'])
         
         def setup_looping_call():
             lc = LoopingCall(self.send)

--- a/lib/stomper/examples/stomper_usage.py
+++ b/lib/stomper/examples/stomper_usage.py
@@ -44,7 +44,7 @@ resp = responder.react(stomper.unpack_frame(response))
 # just returns an empty string.
 
 
-# After a successfull connect you might want to subscribe
+# After a successful connect you might want to subscribe
 # for messages from a destination and tell the server you'll
 # acknowledge all messages.
 #

--- a/lib/stomper/tests/teststompbuffer.py
+++ b/lib/stomper/tests/teststompbuffer.py
@@ -128,7 +128,7 @@ class StompBufferTestCase ( unittest.TestCase ):
         msg1 = self.putAndGetText()
         msg2 = self.sb.getOneMessage()
         self.failUnless ( msg2 is None )
-        # Veryify that in fact the buffer is empty.
+        # Verify that in fact the buffer is empty.
         self.failUnless ( self.sb.bufferIsEmpty() )
 
 
@@ -141,7 +141,7 @@ class StompBufferTestCase ( unittest.TestCase ):
         msg1 = self.putAndGetBinary()
         msg2 = self.sb.getOneMessage()
         self.failUnless ( msg2 is None )
-        # Veryify that in fact the buffer is empty.
+        # Verify that in fact the buffer is empty.
         self.failUnless ( self.sb.bufferIsEmpty() )
 
 

--- a/lib/stomper/tests/teststomper.py
+++ b/lib/stomper/tests/teststomper.py
@@ -70,7 +70,7 @@ class StomperTest(unittest.TestCase):
         # React to an error:
         error = stomper.Frame()
         error.cmd = 'ERROR'
-        error.headers = {'mesage:': 'malformed packet received!'}
+        error.headers = {'message:': 'malformed packet received!'}
         error.body = """The message:
 -----
 MESSAGE


### PR DESCRIPTION
There were a few typos in the doc and comments, this commit fixes them (along with one in a header name)
