### PR TITLE
Fixed newline prepended to messages without transaction id

### DIFF
--- a/lib/stomper/__init__.py
+++ b/lib/stomper/__init__.py
@@ -336,9 +336,9 @@ def send(dest, msg, transactionid=None):
     transheader = ''
 
     if transactionid:
-        transheader = 'transaction: %s' % transactionid
+        transheader = 'transaction: %s\n' % transactionid
 
-    return "SEND\ndestination: %s\n%s\n\n%s\x00\n" % (dest, transheader, msg)
+    return "SEND\ndestination: %s\n%s\n%s\x00\n" % (dest, transheader, msg)
 
 
 def subscribe(dest, ack='auto'):

--- a/lib/stomper/tests/teststomper.py
+++ b/lib/stomper/tests/teststomper.py
@@ -312,7 +312,7 @@ hello queue a
 
     def testSend(self):
         dest, transactionid, msg = '/queue/myplace', '', '123 456 789'
-        correct = "SEND\ndestination: %s\n\n%s\n%s\x00\n" % (dest, '', msg)
+        correct = "SEND\ndestination: %s\n\n%s\x00\n" % (dest, msg)
         result = stomper.send(dest, msg, transactionid)
 
 #        print "result: "


### PR DESCRIPTION
Sending a message without tx id inserts an extra newline which is then parsed as beginning of the message.

I have found this patch in some source of ours: credit goes to a colleague of mine. As well as the blame if his interpretation of the protocol is wrong :)

Example:

```
>>> c.send(stomper.subscribe('/foo'))
>>> c.send(stomper.send('/foo', 'bar'))
>OUT 'SEND\ndestination: /foo\n\n\nbar\x00\n'
>IN {'body': '\nbar', 'headers': {'message-id': '/foo_1', 'destination': '/foo'}, 'cmd': 'MESSAGE'}
```

the body has an extra '\n' in front of the message, whereas

```
>>> c.send(stomper.send('/foo', 'bar', 'asdf'))
>OUT 'SEND\ndestination: /foo\ntransaction: asdf\n\nbar\x00\n'
>IN {'body': 'bar', 'headers': {'message-id': '/foo_2', 'destination': '/foo', 'transaction': 'asdf'}, 'cmd': 'MESSAGE'}
```

no newline here.
