### PR TITLE
Fixed bug with reading README.rst to long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ Stomper distutils file.
 """
 import sys
 from setuptools import setup, find_packages
-
+import io
 
 Name = 'stomper'
 ProjectUrl = "https://github.com/oisinmulvihill/stomper"
@@ -32,7 +32,7 @@ Classifiers = [
 ]
 
 # Recover the ReStructuredText docs:
-Description = open("README.rst").read()
+Description = io.open("README.rst", encoding="utf-8").read()
 
 TestSuite = 'stomper.tests'
 


### PR DESCRIPTION
Hello.

I've found a bug in setup.py in reading README.rst. It appears when you try to build this module in Py3 in environment, where you haven't utf-8 in environment setting. Python3 tries to decode file while read it and as default encoding takes environment setting. When I try to build this module as Fedora package in mock, where Python tries to decode README with ASCII build ended with UnicodeDecodeError.

With io module is possible to define file encoding in open() function, which is handy because this is unsupported in python2.

This bug hasn't impact on most users and I found it only in build system but still I have to say sorry for this.

Is possible to apply this change to existing release?

Thank you for merge and have a nice day.
