### PR TITLE
Treat encoding explicitly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ Classifiers = [
 ]
 
 # Recover the ReStructuredText docs:
-Description = open("README.rst").read()
+Description = open("README.rst", "rb").read().decode("utf-8")
 
 TestSuite = 'stomper.tests'
 


### PR DESCRIPTION
Without this, installation fails on py3 for me.

The README is encoded with utf-8.  If your system defaults to utf-8, then it
works fine.  But my system defaults to ascii which doesn't know what to do with
some of the bytes in the README, and it fails.

If we treat the readme with an explicit encoding (instead of falling back to
the system default) then it works fine.