### PR TITLE
Python >= 3.12: silence "invalid escape sequence" warning

### DIFF
--- a/lib/stomper/stompbuffer.py
+++ b/lib/stomper/stompbuffer.py
@@ -12,16 +12,16 @@ import re
 import stomper
 
 # regexp to check that the buffer starts with a command.
-command_re = re.compile ( '^(.*?)\n' )
+command_re = re.compile ( r'^(.*?)\n' )
 
 # regexp to remove everything up to and including the first
 # instance of '\x00\n' (used in resynching the buffer).
-sync_re = re.compile ( '^.*?\x00\n' )
+sync_re = re.compile ( r'^.*?\x00\n' )
 
 # regexp to determine the content length. The buffer should always start
 # with a command followed by the headers, so the content-length header will
 # always be preceded by a newline.
-content_length_re = re.compile ( '\ncontent-length\s*:\s*(\d+)\s*\n' )
+content_length_re = re.compile ( r'\ncontent-length\s*:\s*(\d+)\s*\n' )
 
 # Separator between the header and the body.
 len_sep = len ( '\n\n' )


### PR DESCRIPTION
Importing this library with Python 3.13 results in a SyntaxWarning:

```
$ python -X pycache_prefix=/dev/null -c 'import stomper'
[..]/lib/python3.13/site-packages/stomper/stompbuffer.py:24:
SyntaxWarning: invalid escape sequence '\s'
  content_length_re = re.compile ( '\ncontent-length\s*:\s*(\d+)\s*\n' )
```

From
https://docs.python.org/3.13/reference/lexical_analysis.html?utm_source=chatgpt.com#escape-sequences:

> Changed in version 3.12:
> Unrecognized escape sequences produce a SyntaxWarning. In a future
> Python version they will be eventually a SyntaxError.

Fix by using raw string literals.

Closes #17.